### PR TITLE
chore: Minor change to remove www from github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["alexdesander <alexdesander@tuta.io>"]
 description = "Simple global channels."
 keywords = ["channel", "global", "sync", "message", "command"]
 categories = ["concurrency"]
-repository = "https://www.github.com/alexdesander/global-channel"
+repository = "https://github.com/alexdesander/global-channel"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 


### PR DESCRIPTION
Github redirects to the address without www anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/96